### PR TITLE
For open source Parse with /parse mounts, this fix helps avoid the pr…

### DIFF
--- a/Parse/src/main/java/com/parse/Parse.java
+++ b/Parse/src/main/java/com/parse/Parse.java
@@ -142,6 +142,13 @@ public class Parse {
        * @return The same builder, for easy chaining.
        */
       public Builder server(String server) {
+
+        // Add an extra trailing slash so that Parse REST commands include
+        // the path as part of the server URL (i.e. http://api.myhost.com/parse)
+        if (server.endsWith("/") == false) {
+          server = server + "/";
+        }
+
         this.server = server;
         return this;
       }

--- a/Parse/src/test/java/com/parse/ParseClientConfigurationTest.java
+++ b/Parse/src/test/java/com/parse/ParseClientConfigurationTest.java
@@ -30,15 +30,29 @@ public class ParseClientConfigurationTest {
     Parse.Configuration.Builder builder = new Parse.Configuration.Builder(null);
     builder.applicationId("foo");
     builder.clientKey("bar");
-    builder.server("some.server");
     builder.enableLocalDataStore();
     Parse.Configuration configuration = builder.build();
 
     assertNull(configuration.context);
     assertEquals(configuration.applicationId, "foo");
     assertEquals(configuration.clientKey, "bar");
-    assertEquals(configuration.server, "some.server");
     assertEquals(configuration.localDataStoreEnabled, true);
+  }
+
+  @Test
+  public void testBuilderServerURL() {
+    Parse.Configuration.Builder builder = new Parse.Configuration.Builder(null);
+    builder.server("http://myserver.com/parse/");
+    Parse.Configuration configuration = builder.build();
+    assertEquals(configuration.server, "http://myserver.com/parse/");
+  }
+
+  @Test
+  public void testBuilderServerMissingSlashURL() {
+    Parse.Configuration.Builder builder = new Parse.Configuration.Builder(null);
+    builder.server("http://myserver.com/missingslash");
+    Parse.Configuration configuration = builder.build();
+    assertEquals(configuration.server, "http://myserver.com/missingslash/");
   }
 
   @Test


### PR DESCRIPTION
…oblem of remembering to add (#436)

the trailing slash.
